### PR TITLE
Bugfix 23: Filter to eliminate empty items from the array of recipients in the form

### DIFF
--- a/server/client/src/utils/validateEmails.js
+++ b/server/client/src/utils/validateEmails.js
@@ -3,9 +3,8 @@ export default (emails) => {
   const invalidEmails = emails
     .split(",")
     .map((email) => email.trim())
-    .filter((email) => {
-      if (email.length) return re.test(email) === false;
-    });
+    .filter(Boolean)
+    .filter((email) => re.test(email) === false);
 
   if (invalidEmails.length) {
     return `These emails are invalid: ${invalidEmails}`;


### PR DESCRIPTION
# Ticket or issue:

[Issue: Fix the return value warning ](https://github.com/oscarpolanco/node_react_fullstack/issues/23)

## Description

Fix the `warning` when the `validation` filter was used on the `recipients` field in the `survey` form page

## Steps to test

- On your terminal go to the `server` directory
- Install all dependencies using: `npm install`
- Start your local `server` using:  `npm start`
- You should not see the `warning` message for the `validateEmails.js` file
- Go to the [survey page](http://localhost:3000/surveys/new)
- Go to the `recipients` field
- Type an `email` that doesn't match with the `regex` validation like `example.com`
- Click outside of the field
- You should see the `error` message
- Click on the `recipients` field
- Add a valid `email` like `example@test.com`
- The validation message should disappear
-  Continue adding another valid `email` like this `example@test.com, example@testing.com`
-  The validation message should not appear after you finish typing

