### PR TITLE
Bugfix 24: Eliminate the anchor tags on the survey list page

### DIFF
--- a/server/client/src/components/surveys/SurveyList.js
+++ b/server/client/src/components/surveys/SurveyList.js
@@ -16,9 +16,11 @@ class SurveyList extends Component {
             <p>{survey.body}</p>
             <div>Sent On: {new Date(survey.dateSent).toLocaleDateString()}</div>
           </div>
-          <div className="card-action">
-            <a>Yes: {survey.yes}</a>
-            <a>No: {survey.no}</a>
+          <div className="card-action row">
+            <span className="col s1 orange-text accent-2">
+              YES: {survey.yes}
+            </span>
+            <span className="col s1 orange-text accent-2">NO: {survey.no}</span>
           </div>
         </div>
       );


### PR DESCRIPTION
# Ticket or issue:

[Bugfix 24: Anchor tags warnings](https://github.com/oscarpolanco/node_react_fullstack/issues/24)

## Description

Eliminate the `anchor` from the `survey` page because that produces a `warning` because it doesn't have an `href`

## Steps to test

- On your terminal go to the `server` directory
- Install all dependencies using: `npm install`
- Start your local `server` using: `npm start`
- You should not see a `warning` for the `SurveryList.js`
- Now on your browser go to the [survey page](http://localhost:3000/surveys)
- You should see the `YES` and `NO` option with a similar style as before
