### PR TITLE
Issue 28: Add husky and run prettier before a commit is made

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,11 @@
     "lint": "npx eslint --ext js ./",
     "eslint-output": "eslint-output"
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "pretty-quick --staged"
+    }
+  },
   "author": "",
   "license": "ISC",
   "dependencies": {
@@ -39,7 +44,9 @@
     "eslint-output": "^2.0.3",
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-node": "^11.1.0",
+    "husky": "^4.2.5",
     "nodemon": "^2.0.3",
-    "prettier": "^2.1.1"
+    "prettier": "^2.1.1",
+    "pretty-quick": "^3.0.0"
   }
 }

--- a/server/sections_text/README.md
+++ b/server/sections_text/README.md
@@ -4577,6 +4577,35 @@ We already did some basic configuration at the beginning on the course phase of 
 - You can add a different set of rules on the `.prettierrc`. This is just personal choices
 - This will be automated later so make sure that you add the set of rules that you need
 
+### Husky and pretty-quick
+
+`Husky` is a package that will help us to manage a certain moment on the `git` flow like to run a certain `script` before `commit` changes or before the `push` changes. `Husky` use hooks that represent this moment on time and you can take advantage of it; in our case, we will run `prettier` when you create a `commit`
+
+#### Steps to configure Husky
+
+- On your terminal go to the `server` directory
+- Install the `husky` and `pretty-quick` as a `dev` dependency
+  `npm install --save-dev husky pretty-quick`
+
+  The `pretty-quick` dependency is a dependency that runs `prettier` on the changes files.
+
+- Now on your editor go to the `package.json` in the `server` directory
+- Bellow the `scripts` section add this new propety:
+
+  ```js
+  "husky": {
+    "hooks": {
+      "pre-commit": "pretty-quick --staged"
+    }
+  }
+  ```
+
+  Here you as you may realize we will add the configuration of `husky`. We only are gonna use the `hooks` property and will set it to run the `pretty-quick` module before creating a `commit`. In other words when you `add` your files and try to `commit` the changes `husky` will run before the commit is finish calling `pretty-quick` that has the `--staged` flag that means that all the staged file will be formatted by `prettier` and they will be re-staged after formating. Now before after you create the `commit` message and press enter you will see a little information of the task that `husky` and `pretty-quick` did
+
+##### Note:
+
+- `Pretty-quick` will respect your `.prettierrc` configuration if it exist
+
 ### Eslint
 
 `Eslint` is a tool that depending on rules that we specify identify and report bugs on our code. This will help the developer team to prevent bugs before pushing the change to the repository.


### PR DESCRIPTION
# Ticket or issue:

[Issue 28: Add eslint and prettier ](https://github.com/oscarpolanco/node_react_fullstack/issues/28)

## Description

<!-- A brief resume of the task -->
Run `prettier` after a commit is made using `husky`

## Steps to test

<!-- A step by step list for local testing -->
- Install all dependencies using: `npm install`
- Go to the `index.js` file in the `server` directory
- Go to line 28
- Between the route and the app parameter press enter
   before => require('./routes/surveyRoutes')(app);
   after =>
    ```js
    require('./routes/surveyRoutes')
    (app);
   ```
- Save the file (make sure that `prettier` don't run on save if you configure this way on your editor)
- On your terminal  add the file: `git add .`
- Commit your update using `git commit -m"this is a test"` (DO NOT PUSH YOUR CHANGES)
- Go to the `index.js` file
- The file should be as originally was before

## Additional Notes

<!-- List of notes relevant to the PR that the reviewer should know -->
- Need to merge this [PR](https://github.com/oscarpolanco/node_react_fullstack/pull/32) first
